### PR TITLE
docs: Link to `stable` docs from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI - Version](https://img.shields.io/pypi/v/pep610.svg)](https://pypi.org/project/pep610)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pep610.svg)](https://pypi.org/project/pep610)
 [![codecov](https://codecov.io/gh/edgarrmondragon/pep610/graph/badge.svg?token=6W1M6P9LYI)](https://codecov.io/gh/edgarrmondragon/pep610)
-[![Documentation Status](https://readthedocs.org/projects/pep610/badge/?version=latest)](https://pep610.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/pep610/badge/?version=latest)](https://pep610.readthedocs.io/en/stable)
 
 [PEP 610][pep610] specifies how the Direct URL Origin of installed distributions should be recorded.
 


### PR DESCRIPTION


<!-- readthedocs-preview pep610 start -->
----
📚 Documentation preview 📚: https://pep610--31.org.readthedocs.build/en/31/

<!-- readthedocs-preview pep610 end -->