### PR TITLE
chore: Bump `coverage` to  7.4.2 to only use "sysmon" when available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = [
 dependencies = [
 ]
 optional-dependencies.dev = [
-  "coverage[toml]>=6.5",
+  "coverage[toml]>=7.4.2",
   "hypothesis",
   "hypothesis-jsonschema",
   'importlib-resources>=5.3; python_version < "3.9"',
@@ -58,14 +58,13 @@ source = "vcs"
 
 [tool.hatch.envs.default]
 dependencies = [
-  "coverage[toml]>=6.5",
+  "coverage[toml]>=7.4.2",
 ]
 features = ["dev"]
+[tool.hatch.envs.default.env-vars]
+COVERAGE_CORE = "sysmon"
 [tool.hatch.envs.default.overrides]
 env.GITHUB_ACTIONS.dev-mode = { value = false, if = ["true"] }
-matrix.python.env-vars = [
-  { key = "COVERAGE_CORE", value = "sysmon", if = ["3.12", "3.13"] }
-]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 doctest = "pytest --doctest-modules {args:src/pep610}"
@@ -76,7 +75,7 @@ python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.10"]
 
 [tool.hatch.envs.coverage]
 dependencies = [
-  "coverage[toml]>=6.5",
+  "coverage[toml]>=7.4.2",
 ]
 detached = true
 [tool.hatch.envs.coverage.scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
@@ -112,6 +113,13 @@ PIP_INSTALL_REPORT = """\
   }
 }
 """
+
+
+def pytest_report_header() -> list[str]:
+    """Return a list of strings to be displayed in the header of the report."""
+    return [
+        f"{key}: {value}" for key, value in os.environ.items() if key.startswith(("COVERAGE_",))
+    ]
 
 
 @pytest.fixture()


### PR DESCRIPTION


<!-- readthedocs-preview pep610 start -->
----
📚 Documentation preview 📚: https://pep610--42.org.readthedocs.build/en/42/

<!-- readthedocs-preview pep610 end -->