### PR TITLE
chore: Remove redundant Ruff `target-version` configl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,6 @@ build = "sphinx-build -W -b html docs docs/_build"
 [tool.ruff]
 line-length = 100
 preview = true
-target-version = "py38"
 
 [tool.ruff.lint]
 ignore = [


### PR DESCRIPTION


<!-- readthedocs-preview pep610 start -->
----
📚 Documentation preview 📚: https://pep610--43.org.readthedocs.build/en/43/

<!-- readthedocs-preview pep610 end -->