### PR TITLE
chore: Keep `direct_url.json` schema in sync with upstream at packaging.python.org

### DIFF
--- a/.github/workflows/update_schema.yaml
+++ b/.github/workflows/update_schema.yaml
@@ -1,0 +1,25 @@
+name: Update direct_url.json schema from packaging.python.org
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "40 12 * * 1-5"
+
+jobs:
+  update_schema:
+    name: Update schema
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Update schema
+        run: |
+          curl -o tests/fixtures/direct_url.schema.json https://packaging.python.org/en/latest/specifications/schemas/direct-url.schema.json
+      - name: Commit changes
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add tests/fixtures/direct_url.schema.json
+          git commit -m "chore: update direct_url.schema.json"
+      - name: Push changes
+        run: |
+          git push

--- a/tests/fixtures/direct_url.schema.json
+++ b/tests/fixtures/direct_url.schema.json
@@ -1,9 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://packaging.python.org/en/latest/specifications/schemas/direct-url.schema.json",
   "title": "Direct URL Data",
   "description": "Data structure that can represent URLs to python projects and distribution artifacts such as VCS source trees, local source trees, source distributions and wheels.",
   "definitions": {
-    "URL": {
+    "url": {
       "type": "string",
       "format": "uri"
     },
@@ -20,12 +21,7 @@
       "properties": {
         "vcs": {
           "type": "string",
-          "enum": [
-            "git",
-            "hg",
-            "bzr",
-            "svn"
-          ]
+          "enum": ["git", "hg", "bzr", "svn"]
         },
         "requested_revision": {
           "type": "string"
@@ -37,10 +33,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "vcs",
-        "commit_id"
-      ]
+      "required": ["vcs", "commit_id"]
     },
     "ArchiveInfo": {
       "type": "object",
@@ -66,15 +59,13 @@
       "type": "object",
       "properties": {
         "url": {
-          "$ref": "#/definitions/URL"
+          "$ref": "#/definitions/url"
         }
       },
-      "required": [
-        "url"
-      ]
+      "required": ["url"]
     },
     {
-      "oneOf": [
+      "anyOf": [
         {
           "type": "object",
           "properties": {
@@ -82,9 +73,7 @@
               "$ref": "#/definitions/DirInfo"
             }
           },
-          "required": [
-            "dir_info"
-          ]
+          "required": ["dir_info"]
         },
         {
           "type": "object",
@@ -93,9 +82,7 @@
               "$ref": "#/definitions/VCSInfo"
             }
           },
-          "required": [
-            "vcs_info"
-          ]
+          "required": ["vcs_info"]
         },
         {
           "type": "object",
@@ -104,9 +91,7 @@
               "$ref": "#/definitions/ArchiveInfo"
             }
           },
-          "required": [
-            "archive_info"
-          ]
+          "required": ["archive_info"]
         }
       ]
     }


### PR DESCRIPTION
- Closes #145 

<!-- readthedocs-preview pep610 start -->
----
📚 Documentation preview 📚: https://pep610--164.org.readthedocs.build/en/164/

<!-- readthedocs-preview pep610 end -->